### PR TITLE
fix: remove version constraints

### DIFF
--- a/examples/deploy_rke2/versions.tf
+++ b/examples/deploy_rke2/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/deploy_rke2_multiple_pools/versions.tf
+++ b/examples/deploy_rke2_multiple_pools/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/import_rke2/modules/cluster/versions.tf
+++ b/examples/import_rke2/modules/cluster/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.7, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/import_rke2/modules/rancher/versions.tf
+++ b/examples/import_rke2/modules/rancher/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"
@@ -43,7 +43,7 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = ">= 4.1.0, < 5.0"
+      version = ">= 5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/import_rke2/versions.tf
+++ b/examples/import_rke2/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"
@@ -43,7 +43,7 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = ">= 4.1.0"
+      version = ">= 5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/one/versions.tf
+++ b/examples/one/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/prod/versions.tf
+++ b/examples/prod/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738136902,
-        "narHash": "sha256-pUvLijVGARw4u793APze3j6mU1Zwdtz7hGkGGkD87qw=",
+        "lastModified": 1740916017,
+        "narHash": "sha256-Ze/3XCElkVljFCnBKezLldOz2ZaGp7eozxRqFzACnMI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a5db3142ce450045840cc8d832b13b8a2018e0c",
+        "rev": "b58e19b11fe72175fd7a9e014a4786a91e99da5f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
               updatecli
               vim
               which
+              xan
               yq-go
             ];
           };

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.7, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/modules/install_cert_manager/configured/versions.tf
+++ b/modules/install_cert_manager/configured/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     helm = {
       source  = "hashicorp/helm"

--- a/modules/install_cert_manager/unconfigured/versions.tf
+++ b/modules/install_cert_manager/unconfigured/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     helm = {
       source  = "hashicorp/helm"
@@ -7,7 +7,7 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = ">= 4.1.0, < 6.0"
+      version = ">= 5.0.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/modules/install_cert_manager/versions.tf
+++ b/modules/install_cert_manager/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     helm = {
       source  = "hashicorp/helm"
@@ -7,7 +7,7 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = ">= 4.1.0, < 6.0"
+      version = ">= 5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/rancher_bootstrap/rancher/versions.tf
+++ b/modules/rancher_bootstrap/rancher/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     helm = {
       source  = "hashicorp/helm"
@@ -7,7 +7,7 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = ">= 5.0.0, < 6.0"
+      version = ">= 5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/rancher_bootstrap/rancher_externalTLS/versions.tf
+++ b/modules/rancher_bootstrap/rancher_externalTLS/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     helm = {
       source  = "hashicorp/helm"
@@ -7,7 +7,7 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = ">= 5.0.0, < 6.0"
+      version = ">= 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/rancher_bootstrap/versions.tf
+++ b/modules/rancher_bootstrap/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"
@@ -43,7 +43,7 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = ">= 5.0"
+      version = ">= 5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This removes the Terraform version constraints and sets the new rancher minimum to v5. 