### PR TITLE
fix: allow for plugin cache

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -208,3 +208,21 @@ jobs:
             echo "Error: Let's Encrypt CA is not being used for verification."
             exit 1
           fi
+
+  test-compile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: install-nix
+        run: |
+          curl -L https://nixos.org/nix/install | sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
+      - name: compile-check
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        run: |
+          cd test/tests
+          go test -c

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742738698,
-        "narHash": "sha256-KCtAXWwQs03JmEhP4ss59QVzT+rHZkhQO85KjNy8Crc=",
+        "lastModified": 1742800061,
+        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3a2a0601e9669a6e38af25b46ce6c4563bcb6da",
+        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
               gitleaks
               gnupg
               go
+              golint
               gotestfmt
               gotestsum
               kubernetes-helm

--- a/modules/install_cert_manager/main.tf
+++ b/modules/install_cert_manager/main.tf
@@ -73,7 +73,14 @@ resource "terraform_data" "create" {
       export KUBE_CONFIG_PATH=${abspath(local.path)}/kubeconfig
       TF_DATA_DIR="${local.path}/install_cert_manager"
       cd ${local.path}/install_cert_manager
-      terraform init -upgrade=true
+      if [ -z "$TF_PLUGIN_CACHE_DIR" ]; then
+        terraform init -upgrade=true
+      else
+        # using a cache directory
+        if [ -n "(ls $TF_PLUGIN_CACHE_DIR/rancher)" ]; then
+          terraform init
+        fi
+      fi
       EXITCODE=1
       ATTEMPTS=0
       MAX=1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,7 +9,12 @@ while getopts ":r:t:p:" opt; do
     r) rerun_failed=true ;;
     t) specific_test="$OPTARG" ;;
     p) specific_package="$OPTARG" ;;
-    \?) echo "Invalid option -$OPTARG" >&2 && exit 1 ;;
+    \?) cat <<EOT >&2 && exit 1 ;;
+Invalid option -$OPTARG, valid options are
+  -r to re-run failed tests
+  -t to specify a specific test (eg. TestBase)
+  -p to specify a specific test package (eg. base)
+EOT
   esac
 done
 

--- a/test/tests/util.go
+++ b/test/tests/util.go
@@ -410,7 +410,7 @@ func Teardown(t *testing.T, directory string, options *terraform.Options, keyPai
       t.Logf("Failed to destroy: %v", err)
     }
 
-    err := os.RemoveAll(directory)
+    err = os.RemoveAll(directory)
     if err != nil {
       t.Logf("Failed to delete test data directory: %v", err)
     }


### PR DESCRIPTION
While injecting a development version of a provider you need to skip the Terraform init phase. In order to skip the init phase you need your providers cached. This enables the submodule to look for and use a plugin cache.

There are also some small QOL changes like adding a compile check for the test suite, adding golint to the environment, and a help message for the run_tests script.