### PR TITLE
fix: replace wait with a test for Rancher

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -231,7 +231,7 @@ jobs:
       - test_TestProdBasic
       - test_TestDownstreamBasic
       - test_TestDownstreamProd
-    if: needs.release.outputs.release_pr
+    if: always() && needs.release.outputs.release_pr
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/modules/rancher_bootstrap/rancher/runningPods.sh
+++ b/modules/rancher_bootstrap/rancher/runningPods.sh
@@ -48,10 +48,10 @@ while readyWait && [ "$SUCCESSES" -lt "$SUCCESSES_NEEDED" ]; do
 done
 
 if [ "$SUCCESSES" -eq "$SUCCESSES_NEEDED" ]; then
-  echo "$SUCCESSES_NEEDED reached, passed.."
+  echo "$SUCCESSES_NEEDED successes reached, passed..."
   EXITCODE=0
 else
-  echo "$SUCCESSES_NEEDED not reached, failed.."
+  echo "$SUCCESSES_NEEDED successes not reached, failed..."
   EXITCODE=1
 fi
 

--- a/modules/rancher_bootstrap/rancher_externalTLS/runningPods.sh
+++ b/modules/rancher_bootstrap/rancher_externalTLS/runningPods.sh
@@ -48,10 +48,10 @@ while readyWait && [ "$SUCCESSES" -lt "$SUCCESSES_NEEDED" ]; do
 done
 
 if [ "$SUCCESSES" -eq "$SUCCESSES_NEEDED" ]; then
-  echo "$SUCCESSES_NEEDED reached, passed.."
+  echo "$SUCCESSES_NEEDED successes reached, passed..."
   EXITCODE=0
 else
-  echo "$SUCCESSES_NEEDED not reached, failed.."
+  echo "$SUCCESSES_NEEDED successes not reached, failed..."
   EXITCODE=1
 fi
 

--- a/test/tests/downstream/downstream_test.go
+++ b/test/tests/downstream/downstream_test.go
@@ -108,17 +108,24 @@ func TestDownstreamBasic(t *testing.T) {
 
   _, err = terraform.InitAndApplyE(t, terraformOptions)
   if err != nil {
+    t.Log("Test failed, tearing down...")
+    util.GetErrorLogs(t, testDir + "/kubeconfig")
     util.Teardown(t, testDir, terraformOptions, keyPair)
     os.Remove(exampleDir + ".terraform.lock.hcl")
     sshAgent.Stop()
     t.Fatalf("Error creating cluster: %s", err)
   }
-  t.Log("Test passed, tearing down...")
+  util.CheckReady(t, testDir + "/kubeconfig")
+  util.CheckRunning(t, testDir + "/kubeconfig")
+  if t.Failed() {
+    t.Log("Test failed...")
+  } else {
+    t.Log("Test passed...")
+  }
   util.Teardown(t, testDir, terraformOptions, keyPair)
-  os.Remove(exampleDir + ".terraform.lock.hcl")
+  os.Remove(exampleDir + "/.terraform.lock.hcl")
   sshAgent.Stop()
 }
-
 
 
 
@@ -214,13 +221,21 @@ func TestDownstreamProd(t *testing.T) {
 
   _, err = terraform.InitAndApplyE(t, terraformOptions)
   if err != nil {
+    t.Log("Test failed, tearing down...")
+    util.GetErrorLogs(t, testDir + "/kubeconfig")
     util.Teardown(t, testDir, terraformOptions, keyPair)
     os.Remove(exampleDir + ".terraform.lock.hcl")
     sshAgent.Stop()
     t.Fatalf("Error creating cluster: %s", err)
   }
-  t.Log("Test passed, tearing down...")
+  util.CheckReady(t, testDir + "/kubeconfig")
+  util.CheckRunning(t, testDir + "/kubeconfig")
+  if t.Failed() {
+    t.Log("Test failed...")
+  } else {
+    t.Log("Test passed...")
+  }
   util.Teardown(t, testDir, terraformOptions, keyPair)
-  os.Remove(exampleDir + ".terraform.lock.hcl")
+  os.Remove(exampleDir + "/.terraform.lock.hcl")
   sshAgent.Stop()
 }

--- a/test/tests/one/one_test.go
+++ b/test/tests/one/one_test.go
@@ -110,6 +110,6 @@ func TestOneBasic(t *testing.T) {
     t.Log("Test passed...")
   }
   util.Teardown(t, testDir, terraformOptions, keyPair)
-  os.Remove(exampleDir + ".terraform.lock.hcl")
+  os.Remove(exampleDir + "/.terraform.lock.hcl")
   sshAgent.Stop()
 }

--- a/test/tests/prod/prod_test.go
+++ b/test/tests/prod/prod_test.go
@@ -94,13 +94,21 @@ func TestProdBasic(t *testing.T) {
   })
   _, err = terraform.InitAndApplyE(t, terraformOptions)
   if err != nil {
+    t.Log("Test failed, tearing down...")
+    util.GetErrorLogs(t, testDir + "/kubeconfig")
     util.Teardown(t, testDir, terraformOptions, keyPair)
     os.Remove(exampleDir + ".terraform.lock.hcl")
     sshAgent.Stop()
     t.Fatalf("Error creating cluster: %s", err)
   }
-  t.Log("Test passed, tearing down...")
+  util.CheckReady(t, testDir + "/kubeconfig")
+  util.CheckRunning(t, testDir + "/kubeconfig")
+  if t.Failed() {
+    t.Log("Test failed...")
+  } else {
+    t.Log("Test passed...")
+  }
   util.Teardown(t, testDir, terraformOptions, keyPair)
-  os.Remove(exampleDir + ".terraform.lock.hcl")
+  os.Remove(exampleDir + "/.terraform.lock.hcl")
   sshAgent.Stop()
 }


### PR DESCRIPTION
ok, so the module keeps working when I run it from my workstation, but it fails in CI. 
I noticed in the logs that the helm chart apply seems to be cut off at 18 minutes, so rather than trust the Helm provider to watch the progress I set the Helm provider not to wait for the chart to succeed before moving on. I then generated a resource that polls kubernetes watching for the pods to complete. I am hoping at the very least this will give us a better understanding of what is causing the CI to fail. 