### PR TITLE
fix: shell needs a dot over the source command

### DIFF
--- a/modules/deploy/create.sh.tpl
+++ b/modules/deploy/create.sh.tpl
@@ -1,5 +1,5 @@
 cd ${deploy_path}
-source envrc
+. envrc
 TF_CLI_ARGS_init=""
 TF_CLI_ARGS_apply=""
 

--- a/modules/deploy/destroy.sh.tpl
+++ b/modules/deploy/destroy.sh.tpl
@@ -1,5 +1,5 @@
 cd ${deploy_path}
-source envrc
+. envrc
 TF_CLI_ARGS_init=""
 TF_CLI_ARGS_apply=""
 if [ -z "${skip_destroy}" ]; then


### PR DESCRIPTION
In the logs there is an error "source not found", it appears that the /bin/sh shell that is executed in the ubuntu GitHub container doesn't have the source command, instead it needs the `.` command.