### PR TITLE
fix: generate create and destroy scripts

### DIFF
--- a/modules/deploy/create.sh.tpl
+++ b/modules/deploy/create.sh.tpl
@@ -1,4 +1,7 @@
-cd ${deploy_path}
+set -x
+pushd ${deploy_path}
+pwd
+ls -lah
 . envrc
 TF_CLI_ARGS_init=""
 TF_CLI_ARGS_apply=""
@@ -51,4 +54,5 @@ if [ $EXITCODE -eq 0 ]; then
   echo "success...";
   terraform output -json -state="${deploy_path}/tfstate" > ${deploy_path}/outputs.json
 fi
+popd
 exit $EXITCODE

--- a/modules/deploy/destroy.sh.tpl
+++ b/modules/deploy/destroy.sh.tpl
@@ -1,4 +1,7 @@
-cd ${deploy_path}
+set -x
+pushd ${deploy_path}
+pwd
+ls -lah
 . envrc
 TF_CLI_ARGS_init=""
 TF_CLI_ARGS_apply=""
@@ -8,3 +11,4 @@ if [ -z "${skip_destroy}" ]; then
 else
   echo "Not destroying deployed module, it will no longer be managed here."
 fi
+popd


### PR DESCRIPTION
This generates the create and destroy scripts before running them. 
This is an attempt to resolve a problem where the CI fails to deploy where my local machine works.
https://github.com/rancher/terraform-rancher2-aws/actions/runs/18329808086