### PR TITLE
fix: add cloud credentials for downstream deploy

### DIFF
--- a/examples/downstream/modules/downstream/main.tf
+++ b/examples/downstream/modules/downstream/main.tf
@@ -98,9 +98,17 @@ resource "aws_vpc_security_group_ingress_rule" "downstream_public_ingress_loadba
   cidr_ipv4         = "${aws_eip.nat.public_ip}/32"
 }
 
+resource "rancher2_cloud_credential" "ec2" {
+  name        = "ec2"
+  description = "ec2 credentials"
+  amazonec2_credential_config {
+    access_key = local.aws_access_key_id
+    secret_key = local.aws_secret_access_key
+  }
+}
 resource "rancher2_machine_config_v2" "nodes" {
   for_each      = local.node_info
-  generate_name = "${each.key}-${local.cluster_name}"
+  generate_name = each.key
   amazonec2_config {
     ami                 = each.value.aws_ami_id
     region              = local.aws_region

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779259093,
-        "narHash": "sha256-7DKWmH23hL2eYdkxCKeqj2i+yljTKuU+3Nk1UPHOnxc=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d99b013d5d1931ad77fe3912ed218170dec5d9a4",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
It seems like the patch to add our temp AWS credentials to the machine config is now being overridden by the credential management system, or at least the lack of credentials in the credential management system is causing problems.
This change adds a cloud credential using our temp SSO credentials while still setting the session token in the machine config to get all of the temp credentials in place (albeit from two different places). 

It also reduces the node config name which doubles up the cluster name because it was getting very close to the 65 character limit.