### PR TITLE
fix: use proper import path for release scripts in container

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const script = await import('${{ github.workspace }}/.github/workflows/scripts/release-pr-comment.js');
+            const script = await import(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/release-pr-comment.js`);
             await script.default({ github, context, core, process });
 
   test:
@@ -166,5 +166,5 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const script = await import('${{ github.workspace }}/.github/workflows/scripts/report-success.js');
+            const script = await import(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/report-success.js`);
             await script.default({ github, context, core, process });

--- a/.github/workflows/update-go-deps.yaml
+++ b/.github/workflows/update-go-deps.yaml
@@ -5,25 +5,34 @@ on:
     - cron: '0 0 * * 1' # Run weekly on Mondays at 00:00
   workflow_dispatch: # Allow manual triggering
 
+permissions: {}
+
 jobs:
   update-deps:
+    name: 'Update Deps'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        id: checkout
+        # https://github.com/actions/checkout/releases
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run Update Script
-        run: |
-          chmod +x ./update-go-deps.sh
-          ./update-go-deps.sh
+        id: run-update-script
+        run: bash .github/workflows/scripts/nix-run.sh "bash .github/workflows/scripts/update-go-deps.sh"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        id: create-pull-request
+        # https://github.com/actions/github-script/releases
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          commit-message: "chore(deps): update go dependencies in test module"
-          title: "chore(deps): update go dependencies in test module"
-          body: "Automated PR to update Go dependencies in the `test` module."
-          branch: "auto-update-go-deps"
-          delete-branch: true
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const script = await import(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/create-update-deps-pr.js`);
+            await script.default({ github, context, core, process });

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783475452,
-        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
+        "lastModified": 1783915482,
+        "narHash": "sha256-FmieJB8/OUvNxbkboi7+IGfIuSXY3nF/hZQm8kD0r50=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
+        "rev": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The path is updated to use the process variable due to running in the container. The previous path was to the script if it were located outside the container.

Also updated update-go-deps to meet new workflow standards.