### PR TITLE
fix: remove release please from container

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!--- If there is no user issue related to this then you should remove the next line --->
+- Addresses: 
+
+## Description
+<!--- Describe your change and how it addresses the issue linked above. --->
+
+
+## Testing
+<!--- Please describe how you verified this change or why testing isn't relevant. --->
+
+
+<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
+<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
+Not a breaking change.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,6 @@ jobs:
   release:
     name: 'Release'
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/rancher/ci-image/nix:20260603-18
     timeout-minutes: 30
     permissions:
       contents: write
@@ -32,9 +30,6 @@ jobs:
         id: checkout
         # https://github.com/actions/checkout/releases
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          fetch-depth: 0
       - name: Release Please
         id: release-please
         # https://github.com/googleapis/release-please-action/releases


### PR DESCRIPTION
It seems like the latest version of release please action calls to docker exec to figure out something on the github runner. This moves the release-please job outside of the ci-image container. 