### PR TITLE
fix: only install colima in darwin systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,6 @@
           age
           awscli2
           bashInteractive
-          colima
           cspell
           curl
           dig
@@ -137,6 +136,8 @@
           which
           xz
           yq-go
+        ] ++ lib.optionals stdenv.isDarwin [
+          colima
         ]);
 
         devShellPackage = pkgs.symlinkJoin {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -367,6 +367,37 @@ check_environment() {
   else
     echo "ZONE: Set"
   fi
+
+  if [ -z "$IDENTIFIER" ]; then
+    echo "WARNING: IDENTIFIER is not set"
+  else
+    echo "IDENTIFIER: Set ($IDENTIFIER)"
+  fi
+
+  if [ -z "$AWS_REGION" ]; then
+    echo "WARNING: AWS_REGION is not set"
+  else
+    echo "AWS_REGION: Set ($AWS_REGION)"
+  fi
+
+  if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "WARNING: AWS_ACCESS_KEY_ID is not set"
+  else
+    echo "AWS_ACCESS_KEY_ID: Set"
+  fi
+
+  if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "WARNING: AWS_SECRET_ACCESS_KEY is not set"
+  else
+    echo "AWS_SECRET_ACCESS_KEY: Set"
+  fi
+
+  if [ -z "$AWS_SESSION_TOKEN" ]; then
+    echo "WARNING: AWS_SESSION_TOKEN is not set"
+  else
+    echo "AWS_SESSION_TOKEN: Set"
+  fi
+
   echo "========================="
   echo ""
 }


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
CI is mysteriously failing with code 1. 
It seems to be having issues downloading or installing colima, which makes sense for an Ubuntu VM. 
This change adds some troubleshooting lines to the run_tests script and makes colima darwin only.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
This only effects the dev environment, not the product.

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
