### PR TITLE
fix: reduce parallelism and Go max processors to prevent CPU pinning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
-    timeout-minutes: 240
+    timeout-minutes: 480 # 8 hours
     permissions:
       contents: read
       id-token: write

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784210874,
-        "narHash": "sha256-x8i+HYAulduMlM63oxWJj5tAm+Sc/W756wUzcV5p24w=",
+        "lastModified": 1785141334,
+        "narHash": "sha256-kh35kIx7el4Jk8Ki3BH9/Pn1eZYSYLJ6LMALos0zOy0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59682e0069f0ed0a452e2179a7f4c1f247027b9e",
+        "rev": "38a4887411571457d700c51c64a6e49ead2ed5ab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,7 @@
           age
           awscli2
           bashInteractive
+          # claude-code
           cspell
           curl
           dig

--- a/modules/deploy/create.sh.tpl
+++ b/modules/deploy/create.sh.tpl
@@ -61,6 +61,7 @@ export TF_PLUGIN_CACHE_DIR="${plugin_cache}"
 echo "Plugin cache directory: $TF_PLUGIN_CACHE_DIR"
 
 export TF_IN_AUTOMATION=1
+export GOMAXPROCS=2
 
 terraform version
 
@@ -92,7 +93,7 @@ while [ $final_exit_code -gt 0 ] && [ $overall_attempt -lt "$max_attempts" ]; do
 
   while [ $apply_exit_code -gt 0 ] && [ $apply_attempt -lt "$max_attempts" ]; do
     # shellcheck disable=SC2154
-    timeout -k 1m "${timeout}" terraform apply -var-file="inputs.tfvars" -no-color -auto-approve -state="tfstate"
+    timeout -k 1m "${timeout}" terraform apply -parallelism=4 -var-file="inputs.tfvars" -no-color -auto-approve -state="tfstate"
     apply_exit_code=$?
 
     if [ $apply_exit_code -eq 124 ]; then echo "Apply timed out after ${timeout}"; fi
@@ -106,7 +107,7 @@ while [ $final_exit_code -gt 0 ] && [ $overall_attempt -lt "$max_attempts" ]; do
 
     while [ $destroy_exit_code -gt 0 ] && [ $destroy_attempt -lt "$max_attempts" ]; do
       # shellcheck disable=SC2154
-      timeout -k 1m "${timeout}" terraform destroy -var-file="inputs.tfvars" -no-color -auto-approve -state="tfstate"
+      timeout -k 1m "${timeout}" terraform destroy -parallelism=4 -var-file="inputs.tfvars" -no-color -auto-approve -state="tfstate"
       destroy_exit_code=$?
 
       if [ $destroy_exit_code -eq 124 ]; then echo "Destroy timed out after ${timeout}"; fi

--- a/modules/deploy/destroy.sh.tpl
+++ b/modules/deploy/destroy.sh.tpl
@@ -61,6 +61,7 @@ export TF_PLUGIN_CACHE_DIR="${plugin_cache}"
 echo "Plugin cache directory: $TF_PLUGIN_CACHE_DIR"
 
 export TF_IN_AUTOMATION=1
+export GOMAXPROCS=2
 
 terraform version
 
@@ -75,7 +76,7 @@ if [ -z "${skip_destroy}" ]; then
   timeout -k 1m "${timeout}" terraform init -no-color
 
   # shellcheck disable=SC2154
-  timeout -k 1m "${timeout}" terraform destroy -var-file="inputs.tfvars" -no-color -auto-approve -state="tfstate" || true
+  timeout -k 1m "${timeout}" terraform destroy -parallelism=4 -var-file="inputs.tfvars" -no-color -auto-approve -state="tfstate" || true
 else
   echo "Not destroying deployed module, it will no longer be managed here."
 fi


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above. --->
Researching a bug found in another repo I found reducing parallelism and GOMAXPROCS can prevent CPU pinning when running Terraform within Terraform. This bug never surfaced in the tests in this repo, but may at scale.
It is important to note that the Terraform runner will need more than 2 processors to run efficiently and 4-8 processors to run at scale.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
This doesn't change any features or operation, it is a proactive attempt to mitigate an issue that was seen in another repo.
All tests pass.

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
